### PR TITLE
Fix GetKeychain and add /api to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ import (
   - `certificate` is the certificate that prove the public key is allowed to be added.
 
   ```golang
-    client := archethic.NewAPIClient("http://localhost:4000/api", "")
+    client := archethic.NewAPIClient("http://localhost:4000", "")
 
     client.AddOriginKey("01103109", "mycertificate")
   ```
@@ -276,7 +276,7 @@ import (
   - `addresses` Transaction address (in hexadecimal)
 
   ```golang
-    client := archethic.NewAPIClient("http://localhost:4000/api", "")
+    client := archethic.NewAPIClient("http://localhost:4000", "")
     client.GetLastTransactionIndex("0000872D96130A2963F1195D1F85FC316AE966644F2E3EE45469C2A257F49C4631C2")
   ``` 
 
@@ -296,7 +296,7 @@ import (
   
   ```golang
   
-    client := archethic.NewAPIClient("http://localhost:4000/api", "")
+    client := archethic.NewAPIClient("http://localhost:4000", "")
 
 	tx := archethic.TransactionBuilder{}
 	tx.SetType(archethic.TransferType)
@@ -316,7 +316,7 @@ import (
   - `addresses`: Transaction address
 
   ```golang
-    client := archethic.NewAPIClient("http://localhost:4000/api", "")
+    client := archethic.NewAPIClient("http://localhost:4000", "")
     client.GetTransactionOwnerships("0000872D96130A2963F1195D1F85FC316AE966644F2E3EE45469C2A257F49C4631C2")
 
   ```
@@ -346,7 +346,7 @@ import (
   - `client` the API client
 
   ```go
-  client := archethic.NewAPIClient("http://localhost:4000/api", "")
+  client := archethic.NewAPIClient("http://localhost:4000", "")
   keychain := archethic.GetKeychain([]byte("seed"), *client)
   ```  
 

--- a/account.go
+++ b/account.go
@@ -70,7 +70,7 @@ func GetKeychain(seed []byte, client APIClient) *Keychain {
 	accessKey := EcDecrypt(accessSecretKey, privateKey)
 	keychainAddress := AesDecrypt(accessSecret, accessKey)
 
-	keychainOwnerships := client.GetTransactionOwnerships(hex.EncodeToString(keychainAddress))
+	keychainOwnerships := client.GetLastTransactionOwnerships(hex.EncodeToString(keychainAddress))
 
 	keychainSecret := keychainOwnerships[0].Secret
 	keychainAuthorizedKeys := keychainOwnerships[0].AuthorizedPublicKeys

--- a/account_test.go
+++ b/account_test.go
@@ -64,7 +64,7 @@ func TestCreateNewAccessKeychainTransaction(t *testing.T) {
 }
 
 func TestShouldGetKeychain(t *testing.T) {
-	client := NewAPIClient("http://localhost:4000/api", "")
+	client := NewAPIClient("http://localhost:4000", "")
 
 	publicKey, _ := DeriveKeypair([]byte("seed"), 0, ED25519)
 	keychainTx := NewKeychainTransaction([]byte("myseed"), [][]byte{publicKey})
@@ -108,7 +108,7 @@ func TestShouldGetKeychain(t *testing.T) {
 				}
 			}
 
-			expectedQuery2 := fmt.Sprintf(`{"query":"query ($address:Address!){transaction(address: $address){data{ownerships{secret,authorizedPublicKeys{encryptedSecretKey,publicKey}}}}}","variables":{"address":"%s"}}
+			expectedQuery2 := fmt.Sprintf(`{"query":"query ($address:Address!){lastTransaction(address: $address){data{ownerships{secret,authorizedPublicKeys{encryptedSecretKey,publicKey}}}}}","variables":{"address":"%s"}}
 `, hex.EncodeToString(keychainTx.Address))
 
 			if reflect.DeepEqual(body, []byte(expectedQuery2)) {
@@ -125,7 +125,7 @@ func TestShouldGetKeychain(t *testing.T) {
 
 				response := fmt.Sprintf(`{
 				        "data": {
-				          "transaction": {
+				          "lastTransaction": {
 				            "data": {
 				              "ownerships": [
 				                {

--- a/api_test.go
+++ b/api_test.go
@@ -16,7 +16,7 @@ func (f MockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 func TestGetNearestEndpoints(t *testing.T) {
-	client := NewAPIClient("http://localhost:4000/api", "")
+	client := NewAPIClient("http://localhost:4000", "")
 	client.InjectHTTPClient(&http.Client{
 		Transport: MockRoundTripper(func(r *http.Request) *http.Response {
 			body, _ := io.ReadAll(r.Body)
@@ -53,7 +53,7 @@ func TestGetNearestEndpoints(t *testing.T) {
 }
 
 func TestGetStorageNoncePublicKey(t *testing.T) {
-	client := NewAPIClient("http://localhost:4000/api", "")
+	client := NewAPIClient("http://localhost:4000", "")
 	client.InjectHTTPClient(&http.Client{
 		Transport: MockRoundTripper(func(r *http.Request) *http.Response {
 			body, _ := io.ReadAll(r.Body)
@@ -85,7 +85,7 @@ func TestGetStorageNoncePublicKey(t *testing.T) {
 }
 
 func TestAddOriginKey(t *testing.T) {
-	client := NewAPIClient("http://localhost:4000/api", "")
+	client := NewAPIClient("http://localhost:4000", "")
 	client.InjectHTTPClient(&http.Client{
 		Transport: MockRoundTripper(func(r *http.Request) *http.Response {
 			if r.URL.String() != "http://localhost:4000/api/origin_key" {
@@ -103,7 +103,7 @@ func TestAddOriginKey(t *testing.T) {
 }
 
 func TestGetOracleData(t *testing.T) {
-	client := NewAPIClient("http://localhost:4000/api", "")
+	client := NewAPIClient("http://localhost:4000", "")
 	client.InjectHTTPClient(&http.Client{
 		Transport: MockRoundTripper(func(r *http.Request) *http.Response {
 			body, _ := io.ReadAll(r.Body)
@@ -139,7 +139,7 @@ func TestGetOracleData(t *testing.T) {
 }
 
 func TestGetOracleDataWithTimestamp(t *testing.T) {
-	client := NewAPIClient("http://localhost:4000/api", "")
+	client := NewAPIClient("http://localhost:4000", "")
 	client.InjectHTTPClient(&http.Client{
 		Transport: MockRoundTripper(func(r *http.Request) *http.Response {
 			body, _ := io.ReadAll(r.Body)
@@ -176,7 +176,7 @@ func TestGetOracleDataWithTimestamp(t *testing.T) {
 }
 
 func TestGetToken(t *testing.T) {
-	client := NewAPIClient("http://localhost:4000/api", "")
+	client := NewAPIClient("http://localhost:4000", "")
 	client.InjectHTTPClient(&http.Client{
 		Transport: MockRoundTripper(func(r *http.Request) *http.Response {
 			body, _ := io.ReadAll(r.Body)


### PR DESCRIPTION
The goal of this PR is to add the missing getLastTransaction query and also to add "/api" to the endpoint URL for the client