### PR TITLE
Add json annotation for keychain service + remove logs

### DIFF
--- a/absinthe.go
+++ b/absinthe.go
@@ -48,11 +48,10 @@ func (a *AbsintheSubscription) GraphqlSubscription(wsUrl, query string, variable
 
 	// Listen for a response and only continue once we know we're joined
 	join.Receive("ok", func(response any) {
-		log.Println("Joined channel:", channel.Topic(), response)
 		cont <- true
 	})
 	join.Receive("error", func(response any) {
-		log.Println("Join error", response)
+		log.Fatalf("Join error: %s", response)
 	})
 
 	// wait to be joined
@@ -87,7 +86,6 @@ func (a *AbsintheSubscription) GraphqlSubscription(wsUrl, query string, variable
 		}
 
 		if subscriptionID != "" {
-			log.Printf("SubscriptionID: %s", subscriptionID)
 			cont <- true
 		}
 	})

--- a/keychain.go
+++ b/keychain.go
@@ -27,9 +27,9 @@ type Keychain struct {
 }
 
 type Service struct {
-	DerivationPath string
-	Curve          Curve
-	HashAlgo       HashAlgo
+	DerivationPath string   `json:"derivationPath"`
+	Curve          Curve    `json:"curve"`
+	HashAlgo       HashAlgo `json:"hashAlgo"`
 }
 
 type DID struct {

--- a/transaction_sender.go
+++ b/transaction_sender.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -110,8 +109,6 @@ func (ts *TransactionSender) SendTransaction(tx *TransactionBuilder, confirmatio
 	go ts.SubscribeTransactionConfirmed(transactionAddress, func() {
 		wg.Done()
 	}, func(transactionConfirmed TransactionConfirmedGQL) {
-		log.Println("Transaction is confirmed")
-		log.Println(transactionConfirmed)
 		if ts.handleConfirmation(confirmationThreshold, transactionConfirmed.NbConfirmations, transactionConfirmed.MaxConfirmations) {
 			done <- true
 		}
@@ -120,8 +117,6 @@ func (ts *TransactionSender) SendTransaction(tx *TransactionBuilder, confirmatio
 	go ts.SubscribeTransactionError(transactionAddress, func() {
 		wg.Done()
 	}, func(transactionError TransactionErrorGQL) {
-		log.Println("Error during transaction")
-		log.Println(transactionError)
 		ts.handleError(string(transactionError.Context), transactionError.Reason)
 		done <- true
 	})


### PR DESCRIPTION
The goal of this PR is to add json annotation to properly display keychain services, but also to remove some logs related to the absinthe connection.
Related to https://github.com/archethic-foundation/archethic-cli/pull/29