### PR TITLE
handle transaction_not_exists error

### DIFF
--- a/account.go
+++ b/account.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"strings"
 )
 
 func NewKeychainTransaction(keychain *Keychain, transactionChainIndex uint32) (*TransactionBuilder, error) {
@@ -80,6 +81,9 @@ func GetKeychain(seed []byte, client APIClient) (*Keychain, error) {
 	}
 	accessOwnerships, err := client.GetTransactionOwnerships(hex.EncodeToString(accessKeychainAddress))
 	if err != nil {
+		if strings.Contains(err.Error(), "transaction_not_exists") {
+			return nil, errors.New("access keychain doesn't exist")
+		}
 		return nil, err
 	}
 	if len(accessOwnerships) == 0 {


### PR DESCRIPTION
The goal of this PR is to return a proper error, when trying to access a keychain for an access keychain that doesn't exist.

Related to https://github.com/archethic-foundation/archethic-cli/issues/30
⚠️ We need to create a new version of libgo and update archethic-cli dependencies to fix the issue