### PR TITLE
Handle new recipient's format (= Transaction version 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ import (
   Adds a recipient to call the smart contract's "transaction" action.
   - `to` is the contract's address in hexadecimal
 
-  #### AddRecipientForNamedAction(to, action, argsJSON)
+  #### AddRecipientForNamedAction(to, action, args)
   Adds a recipient to call a specific smart contract's action.
   - `to` is the contract's address in hexadecimal
   - `action` is the name of the action
-  - `argsJson` is a JSON representing the arguments of the action (ex: "[\"Ron\", 24]")
+  - `args` is the list of arguments of the action
 
   #### Build(seed, index, curve, hashAlgo)
   Generates `address`, `timestamp`, `previousPublicKey`, `previousSignature` of the transaction and

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ import (
   Adds a recipient to call the smart contract's "transaction" action.
   - `to` is the contract's address in hexadecimal
 
-  #### AddRecipientForNamedAction(to, action, args)
+  #### AddRecipientWithNamedAction(to, action, args)
   Adds a recipient to call a specific smart contract's action.
   - `to` is the contract's address in hexadecimal
   - `action` is the name of the action

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ import (
 
   #### ecEncrypt(data, publicKey)
   Perform an ECIES encryption using a public key and a data
-  
+
   - `data` Data to encrypt
   - `publicKey` Public key to derive a shared secret and for whom the content must be encrypted
-  
+
   ```go
   import (
     ...
@@ -97,25 +97,25 @@ import (
    <br/>
 
   `tx := archethic.TransactionBuilder{}` creates a new instance of the transaction
-  
+
   The transaction instance contains the following methods:
-  
+
   #### SetType(type)
   Sets the type of the transaction (could be `TransferType`, `ContractType`, `DataType`, `TokenType`, `HostingType`, `CodeProposalType`, `CodeApprovalType`)
 
   #### SetCode(code)
   Adds the code in the `data.code` section of the transaction
   `code` is a string defining the smart contract
-  
+
   #### SetContent(content)
   Adds the content in the `data.content` section of the transaction
   `content` is a string defining the smart contract
-  
+
   #### AddOwnership(secret, authorizedKeys)
    Adds an ownership in the `data.ownerships` section of the transaction with a secret and its related authorized public keys to be able to decrypt it.
    This aims to prove the ownership or the delegatation of some secret to a given list of public keys.
   `secret` is the slice of bytes representing the encrypted secret
-  `authorizedKeys` is a list of object represented by 
+  `authorizedKeys` is a list of object represented by
   - `publicKey` is the slice of bytes representing the public key
   - `encryptedSecretKey` is the slice of bytes representing the secret key encrypted with the public key (see `ecEncrypt`)
 
@@ -132,20 +132,26 @@ import (
   - `tokenId` is the ID of the token to use
 
   #### AddRecipient(to)
-  Adds a recipient (for non UCO transfers, ie. smart contract interaction) to the `data.recipient` section of the transaction
-  - `to` is the slice of bytes representing the transaction address (recipient)
-  
+  Adds a recipient to call the smart contract's "transaction" action.
+  - `to` is the contract's address in hexadecimal
+
+  #### AddRecipientForNamedAction(to, action, argsJSON)
+  Adds a recipient to call a specific smart contract's action.
+  - `to` is the contract's address in hexadecimal
+  - `action` is the name of the action
+  - `argsJson` is a JSON representing the arguments of the action (ex: "[\"Ron\", 24]")
+
   #### Build(seed, index, curve, hashAlgo)
-  Generates `address`, `timestamp`, `previousPublicKey`, `previousSignature` of the transaction and 
+  Generates `address`, `timestamp`, `previousPublicKey`, `previousSignature` of the transaction and
   serialize it using a custom binary protocol.
-  
+
   - `seed` is the slice of bytes representing the transaction chain seed to be able to derive and generate the keys
   - `index` is the number of transactions in the chain, to generate the actual and the next public key (see below the cryptography section)
   - `curve` is the elliptic curve to use for the key generation (can be "ED25519", "P256", "SECP256K1")
   - `hashAlgo` is the hash algorithm to use to generate the address (can be "SHA256", "SHA512", "SHA3_256", "SHA3_512", "BLAKE2B")
-  
+
   ```go
-  
+
   import(
     ...
     archethic "github.com/archethic-foundation/libgo"
@@ -205,7 +211,7 @@ import (
 	tx.Build([]byte("mysuperpassphraseorseed"), 0, archethic.ED25519, archethic.SHA256)
     json, _ := tx.ToJSON()
   ```
-  
+
   </details>
    <br/>
    <details>
@@ -235,7 +241,7 @@ import (
   ```golang
     client := archethic.NewAPIClient("http://localhost:4000")
     client.GetLastTransactionIndex("0000872D96130A2963F1195D1F85FC316AE966644F2E3EE45469C2A257F49C4631C2")
-  ``` 
+  ```
 
   #### GetStorageNoncePublicKey()
   Query a node to find the public key of the shared storage node key
@@ -244,15 +250,15 @@ import (
   	client := archethic.NewAPIClient("https://testnet.archethic.net/api")
 	client.GetStorageNoncePublicKey()
     // 00017877BCF4122095926A49489009649603AB129822A19EF9D573B8FD714911ED7F
-  ``` 
+  ```
 
   #### GetTransactionFee(tx)
   Query a node to fetch the tx fee for a given transaction
-  
+
   - `tx` Generated transaction
-  
+
   ```golang
-  
+
     client := archethic.NewAPIClient("http://localhost:4000")
 
 	tx := archethic.TransactionBuilder{}
@@ -305,19 +311,19 @@ import (
   ```go
   client := archethic.NewAPIClient("http://localhost:4000")
   keychain := archethic.GetKeychain([]byte("seed"), *client)
-  ```  
+  ```
 
   Once retrieved the keychain provide the following methods:
 
   #### (k Keychain) BuildTransaction(transaction TransactionBuilder, serviceName string, index uint8) TransactionBuilder
-  Generate `address`, `previousPublicKey`, `previousSignature` of the transaction and 
+  Generate `address`, `previousPublicKey`, `previousSignature` of the transaction and
   serialize it using a custom binary protocol, based on the derivation path, curve and hash algo of the service given in param.
 
   - `transaction` is an instance of `TransactionBuilder`
   - `serviceName` is the service name to use for getting the derivation path, the curve and the hash algo
   - `index` is the number of transactions in the chain, to generate the actual and the next public key (see the cryptography section)
 
-  Returns is the signed `TransactionBuilder`. 
+  Returns is the signed `TransactionBuilder`.
 
   ```go
 
@@ -353,19 +359,19 @@ import (
 	keychain := archethic.NewKeychain(seed)
 	publicKey, _ := keychain.DeriveKeypair("uco", 0)
 	address := archethic.DeriveAddress(seed, 0, keychain.Services["uco"].Curve, keychain.Services["uco"].HashAlgo)
-  ``` 
+  ```
 
   #### (k Keychain) DeriveKeypair(serviceName string, index uint8) ([]byte, []byte)
   Derive a keypair for the given service at the index given
 
   - `service`: Service name to identify the derivation path to use
   - `index`: Chain index to derive
-  
+
   ```go
   seed := []byte("abcdefghijklmnopqrstuvwxyz")
 	keychain := archethic.NewKeychain(seed)
 	publicKey, _ := keychain.DeriveKeypair("uco", 0)
-  ``` 
+  ```
 
   #### (k Keychain) ToDID() DID
   Return a Decentralized Identity document from the keychain. (This is used in the transaction's content of the keychain tx)

--- a/transaction_builder.go
+++ b/transaction_builder.go
@@ -14,8 +14,8 @@ type TransactionType uint8
 
 const (
 	Version            uint32          = 2
-	KeychainAccessType TransactionType = 254
 	KeychainType       TransactionType = 255
+	KeychainAccessType TransactionType = 254
 	TransferType       TransactionType = 253
 	HostingType        TransactionType = 252
 	TokenType          TransactionType = 251
@@ -55,12 +55,11 @@ func (t TransactionData) toBytes() []byte {
 	// Encode ownerships
 	buf = append(buf, t.ownershipsBytes()...)
 
-	// Encode recipients
-	buf = append(buf, t.recipientsBytes()...)
-
 	// Encode ledger (UCO + token)
 	buf = append(buf, t.Ledger.toBytes()...)
 
+	// Encode recipients
+	buf = append(buf, t.recipientsBytes()...)
 	return buf
 }
 
@@ -346,8 +345,7 @@ func (t *TransactionBuilder) OriginSign(originPrivateKey []byte) error {
 }
 
 func (t TransactionBuilder) previousSignaturePayload() []byte {
-	versionBytes := []byte{0, 0, 0, 0}
-
+	versionBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(versionBytes, t.Version)
 
 	buf := make([]byte, 0)

--- a/transaction_builder.go
+++ b/transaction_builder.go
@@ -305,7 +305,7 @@ func (t *TransactionBuilder) AddRecipient(address []byte) {
 		Address: address,
 	})
 }
-func (t *TransactionBuilder) AddRecipientForNamedAction(address []byte, action []byte, args []interface{}) {
+func (t *TransactionBuilder) AddRecipientWithNamedAction(address []byte, action []byte, args []interface{}) {
 	t.Data.Recipients = append(t.Data.Recipients, Recipient{
 		Address: address,
 		Action:  action,

--- a/transaction_builder_test.go
+++ b/transaction_builder_test.go
@@ -248,18 +248,6 @@ func TestPreviousSignaturePayload(t *testing.T) {
 	expectedBinary = append(expectedBinary, []byte("0001b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646")...)
 	expectedBinary = append(expectedBinary, []byte("00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
 
-	// Recipients
-	// Nb of bytes to encode nb
-	expectedBinary = append(expectedBinary, []byte{1}...)
-	// Nb of recipients
-	expectedBinary = append(expectedBinary, []byte{2}...)
-	// recipient #1
-	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
-	// recipient #2
-	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
-	expectedBinary = append(expectedBinary, []byte("vote_for_class_president")...)
-	expectedBinary = append(expectedBinary, []byte("[\"Judy\"]")...)
-
 	// Nb of byte to encode nb of uco transfers
 	expectedBinary = append(expectedBinary, []byte{1}...)
 
@@ -281,6 +269,17 @@ func TestPreviousSignaturePayload(t *testing.T) {
 	expectedBinary = append(expectedBinary, []byte{1}...)
 	expectedBinary = append(expectedBinary, []byte{1}...)
 
+	// Recipients
+	// Nb of bytes to encode nb
+	expectedBinary = append(expectedBinary, []byte{1}...)
+	// Nb of recipients
+	expectedBinary = append(expectedBinary, []byte{2}...)
+	// recipient #1
+	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
+	// recipient #2
+	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
+	expectedBinary = append(expectedBinary, []byte("vote_for_class_president")...)
+	expectedBinary = append(expectedBinary, []byte("[\"Judy\"]")...)
 	// expectedBinary = append(expectedBinary, publicKey...)
 	// expectedBinary = append(expectedBinary, EncodeInt32(uint32(len(tx.previousSignature)))...)
 	// expectedBinary = append(expectedBinary, tx.previousSignature...)
@@ -435,14 +434,6 @@ func TestOriginSignaturePayload(t *testing.T) {
 	expectedBinary = append(expectedBinary, []byte("0001a1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646")...)
 	expectedBinary = append(expectedBinary, []byte("00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
 
-	// Recipients
-	// Nb of bytes to encode nb
-	expectedBinary = append(expectedBinary, []byte{1}...)
-	// Nb of recipients
-	expectedBinary = append(expectedBinary, []byte{1}...)
-	// recipient #1
-	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
-
 	// Nb of byte to encode nb of uco transfers
 	expectedBinary = append(expectedBinary, []byte{1}...)
 
@@ -463,6 +454,14 @@ func TestOriginSignaturePayload(t *testing.T) {
 	expectedBinary = append(expectedBinary, EncodeInt64(amount)...)
 	expectedBinary = append(expectedBinary, []byte{1}...)
 	expectedBinary = append(expectedBinary, []byte{1}...)
+
+	// Recipients
+	// Nb of bytes to encode nb
+	expectedBinary = append(expectedBinary, []byte{1}...)
+	// Nb of recipients
+	expectedBinary = append(expectedBinary, []byte{1}...)
+	// recipient #1
+	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
 
 	expectedBinary = append(expectedBinary, publicKey...)
 	expectedBinary = append(expectedBinary, byte(len(tx.PreviousSignature)))

--- a/transaction_builder_test.go
+++ b/transaction_builder_test.go
@@ -204,7 +204,7 @@ func TestPreviousSignaturePayload(t *testing.T) {
 	tx.AddRecipientForNamedAction(
 		[]byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"),
 		[]byte("vote_for_class_president"),
-		[]byte("[\"Judy\"]"))
+		[]interface{}{"Judy"})
 
 	publicKey, _, _ := DeriveKeypair([]byte("seed"), 0, ED25519)
 	address, _ := DeriveAddress([]byte("seed"), 1, ED25519, SHA256)
@@ -507,7 +507,7 @@ func TestToJSONMap(t *testing.T) {
 	tx.SetCode(code)
 	tx.SetContent([]byte(content))
 	tx.AddRecipient(address)
-	tx.AddRecipientForNamedAction(address, []byte("vote_for_class_president"), []byte("[\"Rudy\"]"))
+	tx.AddRecipientForNamedAction(address, []byte("vote_for_class_president"), []interface{}{"Rudy"})
 	tx.AddTokenTransfer(address, address, 33, 65)
 	tx.AddUcoTransfer(address, 64)
 

--- a/transaction_builder_test.go
+++ b/transaction_builder_test.go
@@ -201,7 +201,7 @@ func TestPreviousSignaturePayload(t *testing.T) {
 		[]byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"))
 
 	// a named action
-	tx.AddRecipientForNamedAction(
+	tx.AddRecipientWithNamedAction(
 		[]byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"),
 		[]byte("vote_for_class_president"),
 		[]interface{}{"Judy"})
@@ -507,7 +507,7 @@ func TestToJSONMap(t *testing.T) {
 	tx.SetCode(code)
 	tx.SetContent([]byte(content))
 	tx.AddRecipient(address)
-	tx.AddRecipientForNamedAction(address, []byte("vote_for_class_president"), []interface{}{"Rudy"})
+	tx.AddRecipientWithNamedAction(address, []byte("vote_for_class_president"), []interface{}{"Rudy"})
 	tx.AddTokenTransfer(address, address, 33, 65)
 	tx.AddUcoTransfer(address, 64)
 

--- a/transaction_builder_test.go
+++ b/transaction_builder_test.go
@@ -274,9 +274,11 @@ func TestPreviousSignaturePayload(t *testing.T) {
 	expectedBinary = append(expectedBinary, []byte{1}...)
 	// Nb of recipients
 	expectedBinary = append(expectedBinary, []byte{2}...)
-	// recipient #1
+	// recipient #1 (first byte = unnamed)
+	expectedBinary = append(expectedBinary, []byte{0}...)
 	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
-	// recipient #2
+	// recipient #2 (first byte = named)
+	expectedBinary = append(expectedBinary, []byte{1}...)
 	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
 	expectedBinary = append(expectedBinary, []byte("vote_for_class_president")...)
 	expectedBinary = append(expectedBinary, []byte("[\"Judy\"]")...)
@@ -460,7 +462,8 @@ func TestOriginSignaturePayload(t *testing.T) {
 	expectedBinary = append(expectedBinary, []byte{1}...)
 	// Nb of recipients
 	expectedBinary = append(expectedBinary, []byte{1}...)
-	// recipient #1
+	// recipient #1 (first byte = unnamed)
+	expectedBinary = append(expectedBinary, []byte{0}...)
 	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
 
 	expectedBinary = append(expectedBinary, publicKey...)

--- a/transaction_builder_test.go
+++ b/transaction_builder_test.go
@@ -280,7 +280,12 @@ func TestPreviousSignaturePayload(t *testing.T) {
 	// recipient #2 (first byte = named)
 	expectedBinary = append(expectedBinary, []byte{1}...)
 	expectedBinary = append(expectedBinary, []byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")...)
+	// recipient #2 action
+	expectedBinary = append(expectedBinary, []byte{24}...)
 	expectedBinary = append(expectedBinary, []byte("vote_for_class_president")...)
+	// recipient #2 args
+	expectedBinary = append(expectedBinary, []byte{1}...)
+	expectedBinary = append(expectedBinary, []byte{8}...)
 	expectedBinary = append(expectedBinary, []byte("[\"Judy\"]")...)
 	// expectedBinary = append(expectedBinary, publicKey...)
 	// expectedBinary = append(expectedBinary, EncodeInt32(uint32(len(tx.previousSignature)))...)


### PR DESCRIPTION
New recipient format introduce by AEIP-16: https://github.com/archethic-foundation/archethic-node/pull/1219

Compatibility is kept. No breaking change, just a new function available: `AddRecipientForNamedAction`.

**v1.0.5**
