### PR TITLE
Transaction content is in clear for API

### DIFF
--- a/transaction_builder.go
+++ b/transaction_builder.go
@@ -542,7 +542,7 @@ func (t *TransactionBuilder) ToJSONMap() (map[string]interface{}, error) {
 		}
 	}
 	data := map[string]interface{}{
-		"content":    hex.EncodeToString(t.Data.Content),
+		"content":    string(t.Data.Content),
 		"code":       string(t.Data.Code),
 		"ownerships": ownerships,
 		"ledger": map[string]interface{}{

--- a/transaction_builder_test.go
+++ b/transaction_builder_test.go
@@ -499,7 +499,6 @@ func TestToJSONMap(t *testing.T) {
 	address, _ := hex.DecodeString(addressHex)
 	code := "@version 1\ncondition inherit: []"
 	content := "hello"
-	contentHex := "68656c6c6f"
 
 	// prepare
 	tx := NewTransaction(DataType)
@@ -527,7 +526,7 @@ func TestToJSONMap(t *testing.T) {
 	if data["code"] != code {
 		t.Error("Unexpected code")
 	}
-	if data["content"] != contentHex {
+	if data["content"] != content {
 		t.Error("Unexpected content")
 	}
 


### PR DESCRIPTION
Since https://github.com/archethic-foundation/archethic-node/issues/1232 transaction's content is not anymore encoded in hexadecimal.
Updated API request to send clear content