### PR TITLE
Add recipients typed encoding for args

### DIFF
--- a/transaction_builder.go
+++ b/transaction_builder.go
@@ -66,9 +66,8 @@ func (t TransactionData) toBytes(tx_version uint32) []byte {
 func (t TransactionData) ownershipsBytes() []byte {
 	buf := make([]byte, 0)
 
-	size, ownerShipSize := convertToMinimumBytes(len(t.Ownerships))
-	buf = append(buf, byte(size))
-	buf = append(buf, ownerShipSize...)
+	encodedVarInt := EncodeVarInt(uint64(len(t.Ownerships)))
+	buf = append(buf, encodedVarInt...)
 
 	for i := 0; i < len(t.Ownerships); i++ {
 		buf = append(buf, t.Ownerships[i].toBytes()...)
@@ -79,9 +78,8 @@ func (t TransactionData) ownershipsBytes() []byte {
 func (t TransactionData) recipientsBytes(tx_version uint32) []byte {
 	buf := make([]byte, 0)
 
-	size, recipientsSize := convertToMinimumBytes(len(t.Recipients))
-	buf = append(buf, byte(size))
-	buf = append(buf, recipientsSize...)
+	encodedVarInt := EncodeVarInt(uint64(len(t.Recipients)))
+	buf = append(buf, encodedVarInt...)
 
 	for i := 0; i < len(t.Recipients); i++ {
 		buf = append(buf, t.Recipients[i].toBytes(tx_version)...)
@@ -113,9 +111,8 @@ func (l UcoLedger) toBytes() []byte {
 		ucoBytes = append(ucoBytes, l.Transfers[i].toBytes()...)
 	}
 
-	size, transferSize := convertToMinimumBytes(len(l.Transfers))
-	buf = append(buf, byte(size))
-	buf = append(buf, transferSize...)
+	encodedVarInt := EncodeVarInt(uint64(len(l.Transfers)))
+	buf = append(buf, encodedVarInt...)
 	buf = append(buf, ucoBytes...)
 	return buf
 }
@@ -148,9 +145,8 @@ func (l TokenLedger) toBytes() []byte {
 		tokenBytes = append(tokenBytes, l.Transfers[i].toBytes()...)
 	}
 
-	size, transferSize := convertToMinimumBytes(len(l.Transfers))
-	buf = append(buf, byte(size))
-	buf = append(buf, transferSize...)
+	encodedVarInt := EncodeVarInt(uint64(len(l.Transfers)))
+	buf = append(buf, encodedVarInt...)
 	buf = append(buf, tokenBytes...)
 	return buf
 }
@@ -171,9 +167,8 @@ func (t TokenTransfer) toBytes() []byte {
 	binary.BigEndian.PutUint64(amountBytes, t.Amount)
 	buf = append(buf, amountBytes...)
 
-	size, tokenIdByte := convertToMinimumBytes(t.TokenId)
-	buf = append(buf, byte(size))
-	buf = append(buf, tokenIdByte...)
+	encodedVarInt := EncodeVarInt(uint64(t.TokenId))
+	buf = append(buf, encodedVarInt...)
 
 	return buf
 }
@@ -195,9 +190,8 @@ func (o Ownership) toBytes() []byte {
 		authorizedKeysBuf = append(authorizedKeysBuf, authorizedKey.EncryptedSecretKey...)
 	}
 
-	size, authorizedKeySize := convertToMinimumBytes(len(o.AuthorizedKeys))
-	buf = append(buf, byte(size))
-	buf = append(buf, authorizedKeySize...)
+	encodedVarInt := EncodeVarInt(uint64(len(o.AuthorizedKeys)))
+	buf = append(buf, encodedVarInt...)
 	buf = append(buf, authorizedKeysBuf...)
 
 	return buf
@@ -231,9 +225,8 @@ func (r Recipient) toBytes(tx_version uint32) []byte {
 				panic("invalid recipient's args")
 			}
 
-			size, argsSize := convertToMinimumBytes(len(argsJson))
-			buf = append(buf, byte(size))
-			buf = append(buf, argsSize...)
+			encodedSize := EncodeVarInt(uint64(len(argsJson)))
+			buf = append(buf, encodedSize...)
 			buf = append(buf, argsJson...)
 		}
 	}
@@ -406,73 +399,6 @@ func appendSizeAndContent(buf []byte, input []byte, bitSize int) []byte {
 	}
 	buf = append(buf, input...)
 	return buf
-}
-
-func convertToMinimumBytes(length int) (int, []byte) {
-
-	// determine the minimum number of bytes necessary to represent the length
-	var size int
-	bigIntLength := int64(length)
-
-	switch {
-	case bigIntLength <= 0xff:
-		size = 1
-	case bigIntLength <= 0xffff:
-		size = 2
-	case bigIntLength <= 0xffffff:
-		size = 3
-	case bigIntLength <= 0xffffffff:
-		size = 4
-	case bigIntLength <= 0xffffffffff:
-		size = 5
-	case bigIntLength <= 0xffffffffffff:
-		size = 6
-	case bigIntLength <= 0xffffffffffffff:
-		size = 7
-	default:
-		size = 8
-	}
-
-	// create a byte slice of the appropriate size
-	bytes := make([]byte, size)
-
-	// convert the uint64 length to bytes and store it in the byte slice
-	switch size {
-	case 1:
-		bytes[0] = byte(length)
-	case 2:
-		binary.BigEndian.PutUint16(bytes, uint16(length))
-	case 3:
-		bytes[0] = byte(length & 0xff)
-		bytes[1] = byte((length >> 8) & 0xff)
-		bytes[2] = byte((length >> 16) & 0xff)
-	case 4:
-		binary.BigEndian.PutUint32(bytes, uint32(length))
-	case 5:
-		bytes[0] = byte(length & 0xff)
-		bytes[1] = byte((length >> 8) & 0xff)
-		bytes[2] = byte((length >> 16) & 0xff)
-		bytes[3] = byte((length >> 24) & 0xff)
-		bytes[4] = byte((length >> 32) & 0xff)
-	case 6:
-		bytes[0] = byte(length & 0xff)
-		bytes[1] = byte((length >> 8) & 0xff)
-		bytes[2] = byte((length >> 16) & 0xff)
-		bytes[3] = byte((length >> 24) & 0xff)
-		bytes[4] = byte((length >> 32) & 0xff)
-		bytes[5] = byte((length >> 40) & 0xff)
-	case 7:
-		bytes[0] = byte(length & 0xff)
-		bytes[1] = byte((length >> 8) & 0xff)
-		bytes[2] = byte((length >> 16) & 0xff)
-		bytes[3] = byte((length >> 24) & 0xff)
-		bytes[4] = byte((length >> 32) & 0xff)
-		bytes[5] = byte((length >> 40) & 0xff)
-		bytes[6] = byte((length >> 48) & 0xff)
-	default:
-		binary.BigEndian.PutUint64(bytes, uint64(length))
-	}
-	return size, bytes
 }
 
 func ToUint64(number float64, decimals int) (uint64, error) {

--- a/transaction_builder_test.go
+++ b/transaction_builder_test.go
@@ -200,11 +200,15 @@ func TestPreviousSignaturePayload(t *testing.T) {
 	tx.AddRecipient(
 		[]byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"))
 
+	args := make([]interface{}, 0)
+	args = append(args, "Judy")
+
 	// a named action
 	tx.AddRecipientWithNamedAction(
 		[]byte("0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"),
 		[]byte("vote_for_class_president"),
-		[]interface{}{"Judy"})
+		args,
+	)
 
 	publicKey, _, _ := DeriveKeypair([]byte("seed"), 0, ED25519)
 	address, _ := DeriveAddress([]byte("seed"), 1, ED25519, SHA256)
@@ -216,7 +220,7 @@ func TestPreviousSignaturePayload(t *testing.T) {
 
 	expectedBinary := make([]byte, 0)
 	// Version
-	expectedBinary = append(expectedBinary, EncodeInt32(2)...)
+	expectedBinary = append(expectedBinary, EncodeInt32(3)...)
 	expectedBinary = append(expectedBinary, tx.Address...)
 	expectedBinary = append(expectedBinary, []byte{253}...)
 
@@ -284,17 +288,13 @@ func TestPreviousSignaturePayload(t *testing.T) {
 	expectedBinary = append(expectedBinary, []byte{24}...)
 	expectedBinary = append(expectedBinary, []byte("vote_for_class_president")...)
 	// recipient #2 args
-	expectedBinary = append(expectedBinary, []byte{1}...)
-	expectedBinary = append(expectedBinary, []byte{8}...)
-	expectedBinary = append(expectedBinary, []byte("[\"Judy\"]")...)
-	// expectedBinary = append(expectedBinary, publicKey...)
-	// expectedBinary = append(expectedBinary, EncodeInt32(uint32(len(tx.previousSignature)))...)
-	// expectedBinary = append(expectedBinary, tx.previousSignature...)
+	expectedArgs, _ := SerializeTypedData("Judy")
+	expectedBinary = append(expectedBinary, byte(1))
+	expectedBinary = append(expectedBinary, expectedArgs...)
 
 	if !reflect.DeepEqual(payload, expectedBinary) {
 		t.Errorf("expected payload %v, got %v", expectedBinary, payload)
 	}
-
 }
 
 func TestSetPreviousSignatureAndPreviousPublicKey(t *testing.T) {
@@ -407,7 +407,7 @@ func TestOriginSignaturePayload(t *testing.T) {
 
 	expectedBinary := make([]byte, 0)
 	// Version
-	expectedBinary = append(expectedBinary, EncodeInt32(2)...)
+	expectedBinary = append(expectedBinary, EncodeInt32(3)...)
 	expectedBinary = append(expectedBinary, tx.Address...)
 	expectedBinary = append(expectedBinary, []byte{253}...)
 

--- a/typed_encoding.go
+++ b/typed_encoding.go
@@ -1,50 +1,290 @@
 package archethic
 
-// import (
-// 	"math"
-// )
+import (
+	"fmt"
+	"math"
+	"reflect"
+)
 
-// func Serialize(x int) []byte {
-// 	var signBit = signToBit(x)
-// 	var abs = int(math.Abs(float64(x)))
-// 	_, bytes := convertToMinimumBytes(abs)
+type EncodedType uint8
 
-// 	buf := make([]byte, 0)
-// 	buf = append(buf, byte(0))
-// 	buf = append(buf, byte(signBit))
-// 	buf = append(buf, bytes...)
+const (
+	IntegerType EncodedType = 0
+	FloatType   EncodedType = 1
+	StringType  EncodedType = 2
+	ListType    EncodedType = 3
+	MapType     EncodedType = 4
+	BoolType    EncodedType = 5
+	NilType     EncodedType = 6
+)
 
-// 	return buf
-// }
+func SerializeTypedData(val interface{}) ([]byte, error) {
 
-// func Deserialize(bin []byte) {
+	rVal := reflect.ValueOf(val)
+	switch rVal.Kind() {
+	case reflect.Int:
+		return serializeInt(val.(int)), nil
+	case reflect.Float64:
+		return serializeFloat(val.(float64)), nil
+	case reflect.String:
+		return serializeString(val.(string)), nil
+	case reflect.Map:
+		mapValue := make(map[interface{}]interface{})
+		// Iterate over the map using reflection
+		for _, key := range rVal.MapKeys() {
+			// Convert the key and value to interface{} using reflection
+			interfaceKey := key.Interface()
+			interfaceValue := rVal.MapIndex(key).Interface()
 
-// 	var data = bin[1:]
+			// Assign the key-value pair to the map
+			mapValue[interfaceKey] = interfaceValue
+		}
 
-// 	switch bin[0] {
-// 	case 0:
-// 		return deserializeInt(data)
-// 	}
-// }
+		return serializeMap(mapValue)
+	case reflect.Slice:
+		// Create a new []interface{} slice
+		convertedSlice := make([]interface{}, rVal.Len())
 
-// func deserializeInt(data []byte) (int, []byte) {
-// 	var signBit = data[0]
-// 	var signFactor = bitToSign(uint(signBit))
+		// Iterate over the elements of the slice
+		for i := 0; i < rVal.Len(); i++ {
+			// Perform a type conversion for each element
+			convertedSlice[i] = rVal.Index(i).Interface()
+		}
 
-// }
+		return serializeList(convertedSlice)
+	case reflect.Bool:
+		return serializeBool(val.(bool)), nil
+	case reflect.Invalid:
+		return []byte{byte(NilType)}, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %s", reflect.TypeOf(val))
+	}
+}
 
-// func signToBit(x int) uint {
-// 	if x >= 0 {
-// 		return 1
-// 	} else {
-// 		return 0
-// 	}
-// }
+func serializeInt(number int) []byte {
+	signBit := signToBit[int](number)
+	abs := int(math.Abs(float64(number)))
+	encodedVarInt := EncodeVarInt(uint64(abs))
 
-// func bitToSign(x uint) int {
-// 	if x == 0 {
-// 		return -1
-// 	} else {
-// 		return 1
-// 	}
-// }
+	buf := make([]byte, 0)
+	buf = append(buf, byte(IntegerType))
+	buf = append(buf, byte(signBit))
+	buf = append(buf, encodedVarInt...)
+
+	return buf
+}
+
+func serializeFloat(number float64) []byte {
+	signBit := signToBit[float64](number)
+	abs := math.Abs(float64(number))
+	encodedVarInt := EncodeVarInt(ToBigInt(abs))
+
+	buf := make([]byte, 0)
+	buf = append(buf, byte(FloatType))
+	buf = append(buf, byte(signBit))
+	buf = append(buf, encodedVarInt...)
+
+	return buf
+}
+
+func serializeString(data string) []byte {
+	size := len(data)
+	varIntEncoded := EncodeVarInt(uint64(size))
+
+	buf := make([]byte, 0)
+	buf = append(buf, byte(StringType))
+	buf = append(buf, varIntEncoded...)
+	buf = append(buf, data...)
+
+	return buf
+}
+
+func serializeList(data []any) ([]byte, error) {
+	size := len(data)
+	varIntEncoded := EncodeVarInt(uint64(size))
+
+	buf := make([]byte, 0)
+	buf = append(buf, byte(ListType))
+	buf = append(buf, varIntEncoded...)
+
+	for i := 0; i < size; i++ {
+		bytes, err := SerializeTypedData(data[i])
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, bytes...)
+	}
+
+	return buf, nil
+}
+
+func serializeMap(data map[any]any) ([]byte, error) {
+	size := len(data)
+
+	varIntEncoded := EncodeVarInt(uint64(size))
+
+	buf := make([]byte, 0)
+	buf = append(buf, byte(MapType))
+	buf = append(buf, varIntEncoded...)
+
+	for k, v := range data {
+		k_bytes, err := SerializeTypedData(k)
+		if err != nil {
+			return nil, err
+		}
+
+		v_bytes, err := SerializeTypedData(v)
+		if err != nil {
+			return nil, err
+		}
+
+		buf = append(buf, k_bytes...)
+		buf = append(buf, v_bytes...)
+	}
+
+	return buf, nil
+}
+
+func serializeBool(data bool) []byte {
+	var boolByte byte
+	if data {
+		boolByte = byte(1)
+	} else {
+		boolByte = byte(0)
+	}
+
+	buf := make([]byte, 0)
+	buf = append(buf, byte(BoolType))
+	buf = append(buf, boolByte)
+
+	return buf
+}
+
+func DeserializeTypedData(bin []byte) (any, []byte, error) {
+	var data = bin[1:]
+
+	switch bin[0] {
+	case byte(IntegerType):
+		return deserializeInt(data)
+	case byte(FloatType):
+		return deserializeFloat(data)
+	case byte(StringType):
+		return deserializeString(data)
+	case byte(ListType):
+		return deserializeList(data)
+	case byte(MapType):
+		return deserializeMap(data)
+	case byte(BoolType):
+		return deserializeBool(data)
+	case byte(NilType):
+		return nil, data, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported argument type: %d", bin[0])
+	}
+}
+
+func deserializeInt(data []byte) (int, []byte, error) {
+	var signBit = data[0]
+	var signFactor = bitToSign(uint(signBit))
+	number, remaning_bytes := DecodeVarInt(data[1:])
+	return int(number) * signFactor, remaning_bytes, nil
+}
+
+func deserializeFloat(data []byte) (float64, []byte, error) {
+	var signBit = data[0]
+	var signFactor = bitToSign(uint(signBit))
+	number, remaning_bytes := DecodeVarInt(data[1:])
+
+	return FromBigInt(number) * float64(signFactor), remaning_bytes, nil
+}
+
+func deserializeString(data []byte) (string, []byte, error) {
+	str_size, remaning_bytes := DecodeVarInt(data)
+	str := remaning_bytes[:str_size]
+	return string(str), remaning_bytes[str_size:], nil
+}
+
+func deserializeList(data []byte) ([]any, []byte, error) {
+	var _remaining_bytes []byte
+	list_size, remaining_bytes := DecodeVarInt(data)
+	buf := make([]any, 0)
+
+	_remaining_bytes = remaining_bytes
+
+	for i := 0; i < int(list_size); i++ {
+		data, remaining_bytes, err := DeserializeTypedData(_remaining_bytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		_remaining_bytes = remaining_bytes
+		buf = append(buf, data)
+	}
+	return buf, _remaining_bytes, nil
+}
+
+func deserializeMap(data []byte) (map[any]any, []byte, error) {
+	var _remaining_bytes []byte
+	map_size, remaining_bytes := DecodeVarInt(data)
+	buf := map[any]any{}
+
+	_remaining_bytes = remaining_bytes
+
+	for i := 0; i < int(map_size); i++ {
+		key_data, remaining_bytes, err := DeserializeTypedData(_remaining_bytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		_remaining_bytes = remaining_bytes
+
+		value_data, remaining_bytes, err := DeserializeTypedData(_remaining_bytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		_remaining_bytes = remaining_bytes
+
+		v := reflect.ValueOf(key_data)
+		switch v.Kind() {
+		case reflect.String:
+			buf[key_data.(string)] = value_data
+		case reflect.Int:
+			buf[key_data.(int)] = value_data
+		case reflect.Float64:
+			buf[key_data.(float64)] = value_data
+		case reflect.Bool:
+			buf[key_data.(bool)] = value_data
+		default:
+			return nil, nil, fmt.Errorf("key's type %s is not supported", v.Kind())
+		}
+	}
+
+	return buf, _remaining_bytes, nil
+}
+
+func deserializeBool(data []byte) (bool, []byte, error) {
+	var res bool
+	switch data[0] {
+	case byte(1):
+		res = true
+	case byte(0):
+		res = false
+	default:
+		return false, nil, fmt.Errorf("unsupported byte %x to deserialize bool", data[0])
+	}
+	return res, data[1:], nil
+}
+
+func signToBit[T int | float64](x T) uint {
+	if x >= 0 {
+		return 1
+	} else {
+		return 0
+	}
+}
+
+func bitToSign(x uint) int {
+	if x == 0 {
+		return -1
+	} else {
+		return 1
+	}
+}

--- a/typed_encoding.go
+++ b/typed_encoding.go
@@ -1,0 +1,50 @@
+package archethic
+
+// import (
+// 	"math"
+// )
+
+// func Serialize(x int) []byte {
+// 	var signBit = signToBit(x)
+// 	var abs = int(math.Abs(float64(x)))
+// 	_, bytes := convertToMinimumBytes(abs)
+
+// 	buf := make([]byte, 0)
+// 	buf = append(buf, byte(0))
+// 	buf = append(buf, byte(signBit))
+// 	buf = append(buf, bytes...)
+
+// 	return buf
+// }
+
+// func Deserialize(bin []byte) {
+
+// 	var data = bin[1:]
+
+// 	switch bin[0] {
+// 	case 0:
+// 		return deserializeInt(data)
+// 	}
+// }
+
+// func deserializeInt(data []byte) (int, []byte) {
+// 	var signBit = data[0]
+// 	var signFactor = bitToSign(uint(signBit))
+
+// }
+
+// func signToBit(x int) uint {
+// 	if x >= 0 {
+// 		return 1
+// 	} else {
+// 		return 0
+// 	}
+// }
+
+// func bitToSign(x uint) int {
+// 	if x == 0 {
+// 		return -1
+// 	} else {
+// 		return 1
+// 	}
+// }

--- a/typed_encoding_test.go
+++ b/typed_encoding_test.go
@@ -1,0 +1,213 @@
+package archethic
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSerializeTypedDataInt(t *testing.T) {
+
+	b, _ := SerializeTypedData(10)
+	val, _, _ := DeserializeTypedData(b)
+	if val != 10 {
+		t.Errorf("Expect serialization of int of 10")
+	}
+
+	b, _ = SerializeTypedData(-10)
+	val, _, _ = DeserializeTypedData(b)
+	if val != -10 {
+		t.Errorf("Expect serialization of int of -10")
+	}
+
+	b, _ = SerializeTypedData(1000)
+	val, _, _ = DeserializeTypedData(b)
+	if val != 1000 {
+		t.Errorf("Expect serialization of int of 1000")
+	}
+
+	b, _ = SerializeTypedData(-1000)
+	val, _, _ = DeserializeTypedData(b)
+	if val != -1000 {
+		t.Errorf("Expect serialization of int of -1000")
+	}
+
+	b, _ = SerializeTypedData(100000000)
+	val, _, _ = DeserializeTypedData(b)
+	if val != 100000000 {
+		t.Errorf("Expect serialization of int of 100000000")
+	}
+
+	b, _ = SerializeTypedData(-100000000)
+	val, _, _ = DeserializeTypedData(b)
+	if val != -100000000 {
+		t.Errorf("Expect serialization of int of -100000000")
+	}
+}
+
+func TestSerializeTypedDataFloat(t *testing.T) {
+	b, _ := SerializeTypedData(10.5)
+	val, _, _ := DeserializeTypedData(b)
+	if val != 10.5 {
+		t.Errorf("Expect serialization of float of 10.5")
+	}
+
+	b, _ = SerializeTypedData(-10.5)
+	val, _, _ = DeserializeTypedData(b)
+	if val != -10.5 {
+		t.Errorf("Expect serialization of float of -10.5")
+	}
+
+	b, _ = SerializeTypedData(1000.5020)
+	val, _, _ = DeserializeTypedData(b)
+	if val != 1000.5020 {
+		t.Errorf("Expect serialization of float of 1000.5020")
+	}
+
+	b, _ = SerializeTypedData(-1000.5020)
+	val, _, _ = DeserializeTypedData(b)
+	if val != -1000.5020 {
+		t.Errorf("Expect serialization of float of -1000.5020")
+	}
+
+	b, _ = SerializeTypedData(100000000.249204902904)
+	val, _, _ = DeserializeTypedData(b)
+	if val != 100000000.249204902904 {
+		t.Errorf("Expect serialization of int of 100000000.249204902904")
+	}
+
+	b, _ = SerializeTypedData(-100000000.249204902904)
+	val, _, _ = DeserializeTypedData(b)
+	if val != -100000000.249204902904 {
+		t.Errorf("Expect serialization of float of -100000000.249204902904")
+	}
+}
+
+func TestSerializeTypedDataString(t *testing.T) {
+	b, _ := SerializeTypedData("hello")
+	val, _, _ := DeserializeTypedData(b)
+	if val != "hello" {
+		t.Errorf("Expect serialization of string 'hello'")
+	}
+
+	b, _ = SerializeTypedData("")
+	val, _, _ = DeserializeTypedData(b)
+	if val != "" {
+		t.Errorf("Expect serialization of string '' ")
+	}
+}
+
+func TestSerializeTypedDataList(t *testing.T) {
+	list := []string{"hello"}
+	b, _ := SerializeTypedData(list)
+	val, _, _ := DeserializeTypedData(b)
+
+	interfaceSlice := convertToInterfaceSlice(val)
+	convertedSlice := make([]string, len(interfaceSlice))
+	for i, v := range interfaceSlice {
+		convertedSlice[i] = v.(string)
+	}
+
+	if !reflect.DeepEqual(list, convertedSlice) {
+		t.Errorf("Expect serialization of list ['hello']")
+	}
+
+	list2 := createUntypedSlice()
+	b2, _ := SerializeTypedData(list2)
+	val2, _, _ := DeserializeTypedData(b2)
+
+	if !reflect.DeepEqual(list2, val2) {
+		t.Errorf("Expect serialization of list ['hello']")
+	}
+}
+
+func TestSerializeTypedDataMap(t *testing.T) {
+	m := map[string]string{
+		"hello": "a",
+	}
+
+	b, _ := SerializeTypedData(m)
+	mapValue, _, _ := DeserializeTypedData(b)
+
+	if inputMap, ok := mapValue.(map[string]interface{}); ok {
+		result := make(map[string]string)
+		for key, value := range inputMap {
+			// Check if the value is a string
+			if strValue, ok := value.(string); ok {
+				result[key] = strValue
+			}
+		}
+
+		if !reflect.DeepEqual(result, m) {
+			t.Errorf("Expect serialization of map['hello']:'a'")
+		}
+	}
+}
+
+func TestSerializeTypedDataBool(t *testing.T) {
+	b, _ := SerializeTypedData(true)
+	res, _, _ := DeserializeTypedData(b)
+
+	if res == false {
+		t.Errorf("Expect serialization of `true`")
+	}
+
+	b, _ = SerializeTypedData(false)
+	res, _, _ = DeserializeTypedData(b)
+
+	if res == true {
+		t.Errorf("Expect serialization of `false`")
+	}
+}
+
+func TestSerializeTypedDataNil(t *testing.T) {
+	b, _ := SerializeTypedData(nil)
+	res, _, _ := DeserializeTypedData(b)
+
+	if res != nil {
+		t.Errorf("Expect serialization of `nil`")
+	}
+}
+
+func convertToInterfaceSlice(input interface{}) []interface{} {
+	// Check if the input is already a []interface{}
+	if result, ok := input.([]interface{}); ok {
+		return result
+	}
+
+	// Check if the input is a slice
+	if slice, ok := input.([]interface{}); ok {
+		return slice
+	}
+
+	// Create a new []interface{} slice
+	result := make([]interface{}, 0)
+
+	// Handle other types
+	switch v := input.(type) {
+	case []string:
+		for _, item := range v {
+			result = append(result, item)
+		}
+	case []int:
+		for _, item := range v {
+			result = append(result, item)
+		}
+	// Add more cases for other types as needed
+
+	default:
+		// Handle unsupported types or return an empty slice
+	}
+
+	return result
+}
+
+func createUntypedSlice() []any {
+	buf := make([]any, 0)
+
+	buf = append(buf, 1)
+	buf = append(buf, "hello")
+	buf = append(buf, 2.59)
+	buf = append(buf, true)
+
+	return buf
+}

--- a/utils.go
+++ b/utils.go
@@ -43,7 +43,7 @@ func EncodeVarInt(number uint64) []byte {
 }
 
 // DecodeVarInt convert a VarInt binary into a integer
-func DecodeVarInt(bytes []byte) uint64 {
+func DecodeVarInt(bytes []byte) (uint64, []byte) {
 	size := bytes[0]
 	data := bytes[1 : 1+int(size)]
 
@@ -52,5 +52,13 @@ func DecodeVarInt(bytes []byte) uint64 {
 		value = (value << 8) + int(data[i])
 	}
 
-	return uint64(value)
+	return uint64(value), bytes[size+1:]
+}
+
+func ToBigInt(number float64) uint64 {
+	return uint64(number * float64(100000000))
+}
+
+func FromBigInt(number uint64) float64 {
+	return float64(number) / 100000000
 }

--- a/utils.go
+++ b/utils.go
@@ -22,3 +22,35 @@ func isHex(inputString string) bool {
 	re := regexp.MustCompile("^[0-9A-Fa-f]*$")
 	return re.MatchString(inputString)
 }
+
+// EncodeVarInt converts a number into a VarInt binary
+func EncodeVarInt(number uint64) []byte {
+	if number == 0 {
+		return []byte{1, 0}
+	}
+
+	a := []byte{}
+	for number > 0 {
+		a = append([]byte{byte(number & 255)}, a...)
+		number = number >> 8
+	}
+
+	buf := make([]byte, 0)
+	buf = append(buf, byte(len(a)))
+	buf = append(buf, a...)
+
+	return buf
+}
+
+// DecodeVarInt convert a VarInt binary into a integer
+func DecodeVarInt(bytes []byte) uint64 {
+	size := bytes[0]
+	data := bytes[1 : 1+int(size)]
+
+	value := int(data[0])
+	for i := 1; i < len(data); i++ {
+		value = (value << 8) + int(data[i])
+	}
+
+	return uint64(value)
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,171 @@
+package archethic
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestEncodeVarInt(t *testing.T) {
+
+	var expected, actual []byte
+
+	expected = []byte{1, 0}
+	actual = EncodeVarInt(0)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{1, 255}
+	actual = EncodeVarInt(uint64(math.Pow(2, 8)) - 1)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{2, 1, 0}
+	actual = EncodeVarInt(uint64(math.Pow(2, 8)))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{2, 255, 255}
+	actual = EncodeVarInt(uint64(math.Pow(2, 16)) - 1)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{3, 1, 0, 0}
+	actual = EncodeVarInt(uint64(math.Pow(2, 16)))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{3, 255, 255, 255}
+	actual = EncodeVarInt(uint64(math.Pow(2, 24)) - 1)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{4, 1, 0, 0, 0}
+	actual = EncodeVarInt(uint64(math.Pow(2, 24)))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{4, 255, 255, 255, 255}
+	actual = EncodeVarInt(uint64(math.Pow(2, 32)) - 1)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{5, 1, 0, 0, 0, 0}
+	actual = EncodeVarInt(uint64(math.Pow(2, 32)))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{5, 255, 255, 255, 255, 255}
+	actual = EncodeVarInt(uint64(math.Pow(2, 40)) - 1)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	expected = []byte{6, 1, 0, 0, 0, 0, 0}
+	actual = EncodeVarInt(uint64(math.Pow(2, 40)))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+}
+
+func TestDecodeVarInt(t *testing.T) {
+
+	var actual, expected uint64
+
+	actual = DecodeVarInt([]byte{1, 0})
+	expected = uint64(0)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{1, 255})
+	expected = uint64(math.Pow(2, 8)) - 1
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{2, 1, 0})
+	expected = uint64(math.Pow(2, 8))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{2, 255, 255})
+	expected = uint64(math.Pow(2, 16)) - 1
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{3, 1, 0, 0})
+	expected = uint64(math.Pow(2, 16))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{3, 255, 255, 255})
+	expected = uint64(math.Pow(2, 24)) - 1
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{4, 1, 0, 0, 0})
+	expected = uint64(math.Pow(2, 24))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{4, 255, 255, 255, 255})
+	expected = uint64(math.Pow(2, 32)) - 1
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{5, 1, 0, 0, 0, 0})
+	expected = uint64(math.Pow(2, 32))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{5, 255, 255, 255, 255, 255})
+	expected = uint64(math.Pow(2, 40)) - 1
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+
+	actual = DecodeVarInt([]byte{6, 1, 0, 0, 0, 0, 0})
+	expected = uint64(math.Pow(2, 40))
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual %q, expected %q", actual, expected)
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -92,77 +92,77 @@ func TestDecodeVarInt(t *testing.T) {
 
 	var actual, expected uint64
 
-	actual = DecodeVarInt([]byte{1, 0})
+	actual, _ = DecodeVarInt([]byte{1, 0})
 	expected = uint64(0)
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{1, 255})
+	actual, _ = DecodeVarInt([]byte{1, 255})
 	expected = uint64(math.Pow(2, 8)) - 1
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{2, 1, 0})
+	actual, _ = DecodeVarInt([]byte{2, 1, 0})
 	expected = uint64(math.Pow(2, 8))
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{2, 255, 255})
+	actual, _ = DecodeVarInt([]byte{2, 255, 255})
 	expected = uint64(math.Pow(2, 16)) - 1
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{3, 1, 0, 0})
+	actual, _ = DecodeVarInt([]byte{3, 1, 0, 0})
 	expected = uint64(math.Pow(2, 16))
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{3, 255, 255, 255})
+	actual, _ = DecodeVarInt([]byte{3, 255, 255, 255})
 	expected = uint64(math.Pow(2, 24)) - 1
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{4, 1, 0, 0, 0})
+	actual, _ = DecodeVarInt([]byte{4, 1, 0, 0, 0})
 	expected = uint64(math.Pow(2, 24))
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{4, 255, 255, 255, 255})
+	actual, _ = DecodeVarInt([]byte{4, 255, 255, 255, 255})
 	expected = uint64(math.Pow(2, 32)) - 1
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{5, 1, 0, 0, 0, 0})
+	actual, _ = DecodeVarInt([]byte{5, 1, 0, 0, 0, 0})
 	expected = uint64(math.Pow(2, 32))
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{5, 255, 255, 255, 255, 255})
+	actual, _ = DecodeVarInt([]byte{5, 255, 255, 255, 255, 255})
 	expected = uint64(math.Pow(2, 40)) - 1
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("actual %q, expected %q", actual, expected)
 	}
 
-	actual = DecodeVarInt([]byte{6, 1, 0, 0, 0, 0, 0})
+	actual, _ = DecodeVarInt([]byte{6, 1, 0, 0, 0, 0, 0})
 	expected = uint64(math.Pow(2, 40))
 
 	if !reflect.DeepEqual(expected, actual) {


### PR DESCRIPTION
This change is introduced by transaction version 3: https://github.com/archethic-foundation/archethic-node/pull/1304

Add new serialization for the recipients, because JSON is too big and it has the bad habit of converting floats to scientific notation, which result in different signatures.
